### PR TITLE
[feature][ci] add check-pr-title ci action

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, edited]
     branches:
-      - develop
+      - master
   workflow_call:
     outputs:
       is_pr_title_valid:

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -28,7 +28,7 @@ jobs:
             core.setOutput('is_pr_title_valid', isValid.toString());
 
             if (!isValid) {
-              core.setFailed(`❌ PR title "${prTitle}" does not match the required pattern. Make sure it starts with two sets of square brackets and a summary.`);
+              core.setFailed(`❌ PR title "${prTitle}" does not match the required pattern. Make sure it follow Semantic PR definition '[category][scope] description'.`);
             } else {
               core.info(`✅ PR title "${prTitle}" matches the pattern.`);
             }

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,34 @@
+name: Check PR Title Format
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+    branches:
+      - develop
+  workflow_call:
+    outputs:
+      is_pr_title_valid:
+        description: "Is the PR title format correct"
+        value: ${{ jobs.check-pr-title.outputs.is_pr_title_valid }}
+
+jobs:
+  check-pr-title:
+    runs-on: self-hosted
+    outputs:
+      is_pr_title_valid: ${{ steps.check-pr-title.outputs.is_pr_title_valid }}
+    steps:
+      - name: Check PR Title
+        id: check-pr-title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prTitle = context.payload.pull_request.title;
+            const pattern = /^\[[^\]]+\]\[[^\]]+\] .+/;
+            const isValid = pattern.test(prTitle);
+            core.setOutput('is_pr_title_valid', isValid.toString());
+
+            if (!isValid) {
+              core.setFailed(`❌ PR title "${prTitle}" does not match the required pattern. Make sure it starts with two sets of square brackets and a summary.`);
+            } else {
+              core.info(`✅ PR title "${prTitle}" matches the pattern.`);
+            }

--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@ jobs:
 1. 利用したいレポジトリのルートに`.pre-commit-config.yaml`を配置する
 1. pip3 install pre-commit
 1. pre-commit install
+
+### Check PR Title
+
+To enable this workflow, add the `check-pr-title.yml` file to your repository under the `.github/workflows/` directory.
+Ensure that GitHub Actions are enabled in your repository. When a pull request is opened, edited, or synchronized, the workflow will automatically check whether the PR title follows the Semantic PR naming convention.
+
+このワークフローを有効にするには、リポジトリの `.github/workflows/` ディレクトリに `check-pr-title.yml` ファイルを追加してください。
+また、リポジトリで GitHub Actions が有効になっていることを確認してください。
+プルリクエストが作成・編集・同期された際に、ワークフローが自動的にタイトルをチェックし、Semantic PR の命名規則に従っているかを確認します。


### PR DESCRIPTION
Adds a check-pr-title workflow to check if a PR title follows the [Semantic Pull Request convention](https://pulsar.apache.org/contribute/develop-semantic-title/).
プルリクエストが作成・編集・同期された際に、ワークフローが自動的にタイトルをチェックし、[Semantic PR](https://pulsar.apache.org/contribute/develop-semantic-title/) の命名規則に従っているかを確認します。